### PR TITLE
Fix build warning in section container

### DIFF
--- a/Source/INTUGroupedArray/Internal/INTUGroupedArraySectionContainer.h
+++ b/Source/INTUGroupedArray/Internal/INTUGroupedArraySectionContainer.h
@@ -52,7 +52,7 @@ __INTU_ASSUME_NONNULL_BEGIN
 @interface __INTU_GENERICS(INTUMutableGroupedArraySectionContainer, SectionType, ObjectType) : INTUGroupedArraySectionContainer
 
 /** Exposes the superclass objects instance variable typecast to NSMutableArray. */
-@property (nonatomic) __INTU_GENERICS(NSMutableArray, ObjectType) *mutableObjects;
+@property (nonatomic, strong) __INTU_GENERICS(NSMutableArray, ObjectType) *mutableObjects;
 
 __INTU_ASSUME_NONNULL_END
 


### PR DESCRIPTION
Hi all,

This warning comes up when building the library as part of a module (dynamic frameworks). Seems `strong` is not assumed here, but rather `assign`.

```
While building module 'INTUGroupedArray' imported from ~/dev/<REDACTED>/<REDACTED>/Classes/<REDACTED>-Prefix.pch:41:
In file included from <module-includes>:1:
In file included from ~/Library/Developer/Xcode/DerivedData/<REDACTED>-cekmbhpfhfikusczqupagemyzjvx/Build/Products/Debug-iphonesimulator/INTUGroupedArray.framework/Headers/INTUGroupedArray-umbrella.h:4:
In file included from ~/Library/Developer/Xcode/DerivedData/<REDACTED>-cekmbhpfhfikusczqupagemyzjvx/Build/Products/Debug-iphonesimulator/INTUGroupedArray.framework/Headers/INTUGroupedArrayInternal.h:32:
~/Library/Developer/Xcode/DerivedData/<REDACTED>-cekmbhpfhfikusczqupagemyzjvx/Build/Products/Debug-iphonesimulator/INTUGroupedArray.framework/Headers/INTUGroupedArraySectionContainer.h:55:1: warning: no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed [-Wobjc-property-no-attribute]
@property (nonatomic) __INTU_GENERICS(NSMutableArray, ObjectType) *mutableObjects;
^
~/Library/Developer/Xcode/DerivedData/<REDACTED>-cekmbhpfhfikusczqupagemyzjvx/Build/Products/Debug-iphonesimulator/INTUGroupedArray.framework/Headers/INTUGroupedArraySectionContainer.h:55:1: warning: default property attribute 'assign' not appropriate for non-GC object [-Wobjc-property-no-attribute]
2 warnings generated.
2 warnings generated.
```

![screen shot 2015-09-25 at 15 36 32](https://cloud.githubusercontent.com/assets/557391/10101969/44f03a86-639c-11e5-9bf7-37fb33712423.png)
